### PR TITLE
ENH: Add schema to form feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,3 @@ COPY package*.json ./
 
 # install project dependencies
 RUN npm install
-
-# copy project files and folders to the current working directory (i.e. 'app' folder)
-COPY . .

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  sourceType: 'unambiguous',
   presets: [
     '@vue/app'
   ]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "npm": "^6.14.3",
     "sass": "^1.26.3",
     "sass-loader": "^7.3.1",
-    "vue": "^2.6.6",
+    "vue": "^2.6.11",
     "vue-axios": "^2.1.5",
     "vue-chartjs": "^3.4.2",
     "vue-instant": "^1.0.2",
@@ -39,7 +39,7 @@
     "babel-jest": "^23.6.0",
     "vue-bokeh": "^0.2.0",
     "vue-cli-plugin-bootstrap": "^1.0.0-alpha.1",
-    "vue-template-compiler": "^2.5.21",
+    "vue-template-compiler": "^2.6.11",
     "webpack-license-plugin": "^4.0.0"
   },
   "postcss": {

--- a/package.json
+++ b/package.json
@@ -8,18 +8,26 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "axios": "^0.19.0",
-    "bokehjs": "^1.1.0",
+    "@koumoul/vuetify-jsonschema-form": "^0.36.4",
+    "axios": "^0.19.2",
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.12",
     "chart.js": "^2.8.0",
     "d3": "^5.9.2",
     "flush-promises": "^1.0.2",
+    "hjson": "^3.2.1",
+    "install": "^0.13.0",
     "jquery": "^3.4.1",
+    "node-sass": "^4.13.1",
+    "npm": "^6.14.3",
+    "sass": "^1.26.3",
+    "sass-loader": "^7.3.1",
     "vue": "^2.6.6",
+    "vue-axios": "^2.1.5",
     "vue-chartjs": "^3.4.2",
     "vue-instant": "^1.0.2",
     "vue-router": "^3.0.1",
+    "vuetify": "^2.2.19",
     "vuex": "^3.1.0"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
     <script src="https://unpkg.com/vue-chartjs/dist/vue-chartjs.min.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
 
     <!--
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bokeh/1.1.0/bokeh.min.css" integrity="sha256-kmX/Nb5PazwKydPmaZjEb9sOg8BWh1v5eP14IzXJUkU=" crossorigin="anonymous" />

--- a/src/components/FormFactory.vue
+++ b/src/components/FormFactory.vue
@@ -1,0 +1,140 @@
+<template lang="html">
+  <div id="form-factory">
+    <v-app>
+      <v-content>
+        <v-container fluid grid-list-md>
+          <v-layout row>
+            <v-flex xs6>
+              <v-form ref="myForm" v-model="formValid">
+                <v-jsonschema-form
+                  v-if="schema"
+                  :schema="schema"
+                  :model="dataObject"
+                  :options="options"
+                  @error="e => window.alert(e)"
+                  @change="change"
+                  @input="input"
+                >
+                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
+                    Prepend slot<br>
+                  </template>
+                  <template v-slot:append-fullKeySlot="{fullSchema}">
+                    Append slot
+                  </template>
+                  <template v-slot:fullKeySlot="{fullSchema}">
+                    Full key slot: {{ fullSchema.description }}<br>
+                  </template>
+                  <template v-slot:custom-1="{fullSchema}">
+                    Custom display slot: {{ fullSchema.description }}
+                  </template>
+                </v-jsonschema-form>
+                <v-btn @click="handleClick">Add User</v-btn>
+                     <v-btn
+        color="error"
+        class="mr-4"
+        @click="reset"
+      >
+        Reset Form
+      </v-btn> 
+              </v-form>
+              <h2 class="title my-4" style="text-align: left;">
+                Data:
+              </h2>
+              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-content>
+    </v-app>
+  </div>
+</template>
+
+<script>
+import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
+//import examples from './examples'
+import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+
+export default {
+  name: 'form-factory',
+  components: { VJsonschemaForm },
+  props: {
+    example: Object,
+  },
+  data: function() {
+    return {
+      window,
+      schema: null,
+      schemaStr: '{}',
+      schemaError: null,
+      dataObject: {},
+      //examples,
+      formValid: false,
+      options: null
+    }
+  },
+  mounted() {
+    if (window.location.search) {
+      //const key = window.location.search.replace('?example=', '')
+      //this.example = examples.find(e => e.key === key)
+    }
+    this.applyExample()
+  },
+  methods: {
+    applySchema() {
+      try {
+        this.schema = hjson.parse(this.schemaStr)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    formatSchema() {
+      try {
+        const schema = hjson.parse(this.schemaStr)
+        this.schemaStr = JSON.stringify(schema, null, 2)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    applyExample() {
+      const queryParams = `?example=${this.example.key}`
+      if (window.location.search !== queryParams) window.location.search = queryParams
+
+      this.schema = null
+      setTimeout(() => {
+        this.options = {
+          debug: true,
+          disableAll: false,
+          autoFoldObjects: true,
+          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
+          accordionMode: 'normal',
+          ...this.example.options || {}
+        }
+        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
+        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
+        this.applySchema()
+      }, 1)
+    },
+    change(e) {
+      console.log('"change" event', e)
+    },
+    input(e) {
+      console.log('"input" event', e)
+    },
+    handleClick() {
+      console.log('Add Sample clicked')
+      //axios.post('api/experiments', dataObject)
+    },
+    reset() {
+      this.$refs.myForm.reset()
+    },
+  }
+}
+</script>
+
+<style lang="css">
+  pre {
+    text-align: left;
+  }
+</style>

--- a/src/components/FormFactory.vue
+++ b/src/components/FormFactory.vue
@@ -53,6 +53,7 @@
 import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
 //import examples from './examples'
 import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+import axios from 'axios'
 
 export default {
   name: 'form-factory',
@@ -69,7 +70,8 @@ export default {
       dataObject: {},
       //examples,
       formValid: false,
-      options: null
+      options: null,
+      axios: axios,
     }
   },
   mounted() {
@@ -104,6 +106,7 @@ export default {
       this.schema = null
       setTimeout(() => {
         this.options = {
+          httpLib: this.axios,
           debug: true,
           disableAll: false,
           autoFoldObjects: true,

--- a/src/components/HomeLinks.vue
+++ b/src/components/HomeLinks.vue
@@ -2,7 +2,7 @@
   <div>
     <div>
         <b-card-group deck>
-          
+
              <b-nav>
               <b-nav-item v-bind:to="'/compounds'">
                 <b-card>Compounds </b-card>
@@ -34,14 +34,38 @@
             </b-nav>
        
   
-         <b-nav>
+            <b-nav>
               <b-nav-item v-bind:to="'/'">
                 <b-card>Publications </b-card>
               </b-nav-item>
             </b-nav>
-          <b-nav>
+            <b-nav>
               <b-nav-item v-bind:to="'/'">
                 <b-card>News </b-card>
+              </b-nav-item>
+            </b-nav>
+        </b-card-group>
+    </div>
+    <div class="mt-3">
+        <b-card-group deck>
+           <b-nav>
+              <b-nav-item v-bind:to="'/userform'">
+                <b-card>Schema2Form Dev</b-card>
+              </b-nav-item>
+            </b-nav>
+            <b-nav>
+              <b-nav-item v-bind:to="'/adduser'">
+                <b-card>Add User </b-card>
+              </b-nav-item>
+            </b-nav>
+            <b-nav>
+              <b-nav-item v-bind:to="'/addexperiment'">
+                <b-card>Add Experiment </b-card>
+              </b-nav-item>
+            </b-nav>
+            <b-nav>
+              <b-nav-item v-bind:to="'/addcompound'">
+                <b-card>Add Compound </b-card>
               </b-nav-item>
             </b-nav>
         </b-card-group>

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ import router from './router'
 import store from './store'
 import './assets/css/main.css'
 import axios from 'axios'
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
 
 
 Vue.config.productionTip = false
@@ -22,10 +24,13 @@ Vue.use({
     Vue.prototype.$runs_url = process.env.VUE_APP_API_URL + '/runs'
   }
 })
+const vuetifyOptions = { }
+Vue.use(Vuetify)
 
 new Vue({
   router,
   store,
+  vuetify: new Vuetify(vuetifyOptions),
   render: h => h(App)
 }).$mount('#app')
 

--- a/src/router.js
+++ b/src/router.js
@@ -59,10 +59,30 @@ export default new Router({
       name: 'runschartjs',
       component: () => import(/* webpackChunkName: "run" */ './views/RunData.vue')
     },
-    { 
-        path: '/experiments',
-        name: 'experiments',
-        component: () => import(/* webpackChunkName: "experiments" */ './views/Experiments.vue')
-    }
+    {
+      path: '/experiments',
+      name: 'experiments',
+      component: () => import(/* webpackChunkName: "experiments" */ './views/Experiments.vue')
+    },
+    {
+      path: '/userform',
+      name: 'userform',
+      component: () => import(/* webpackChunkName: "userform" */ './views/DemoApp.vue')
+    },
+    {
+      path: '/adduser',
+      name: 'adduser',
+      component: () => import(/* webpackChunkName: "adduser" */ './views/AddUser.vue')
+    },
+    {
+      path: '/addexperiment',
+      name: 'addexperiment',
+      component: () => import(/* webpackChunkName: "addexperiment" */ './views/AddExperiment.vue')
+    },
+    {
+      path: '/addcompound',
+      name: 'addcompound',
+      component: () => import(/* webpackChunkName: "addcompound" */ './views/AddCompound.vue')
+    },
   ]
 })

--- a/src/schema/compounds_schema.json
+++ b/src/schema/compounds_schema.json
@@ -1,0 +1,126 @@
+{
+    "definitions": {},
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/root.json",
+    "type": "object",
+    "title": "The Root Schema",
+    "required": [
+      "name",
+      "technique",
+      "experiment_metadata",
+      "researcher",
+      "experimental_conditions",
+      "trials"
+    ],
+    "properties": {
+      "name": {
+        "$id": "#/properties/name",
+        "type": "string",
+        "title": "The Name Schema",
+        "default": "",
+        "examples": [
+          "Ion Exchange Membrane Sorption Tests"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "technique": {
+        "$id": "#/properties/technique",
+        "type": "object",
+        "title": "The Technique Schema",
+        "required": [
+          "name",
+          "technique_metadata"
+        ],
+        "properties": {
+          "name": {
+            "$id": "#/properties/technique/properties/name",
+            "type": "string",
+            "title": "The Name Schema",
+            "default": "",
+            "examples": [
+              "ion_exhcange_counter_and_mobile"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "technique_metadata": {
+            "$id": "#/properties/technique/properties/technique_metadata",
+            "type": "object",
+            "title": "The Technique_metadata Schema"
+          }
+        }
+      },
+      "experiment_metadata": {
+        "$id": "#/properties/experiment_metadata",
+        "type": "object",
+        "title": "The Experiment_metadata Schema"
+      },
+      "researcher": {
+        "$id": "#/properties/researcher",
+        "type": "object",
+        "title": "The Researcher Schema",
+        "required": [
+          "mwet_id",
+          "name",
+          "group",
+          "institution"
+        ],
+        "properties": {
+          "mwet_id": {
+            "$id": "#/properties/researcher/properties/mwet_id",
+            "type": "string",
+            "title": "The Mwet_id Schema",
+            "default": "",
+            "examples": [
+              "foo2"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "name": {
+            "$id": "#/properties/researcher/properties/name",
+            "type": "string",
+            "title": "The Name Schema",
+            "default": "",
+            "examples": [
+              "Rahul Sujanani"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "group": {
+            "$id": "#/properties/researcher/properties/group",
+            "type": "string",
+            "title": "The Group Schema",
+            "default": "",
+            "examples": [
+              "Freeman"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "institution": {
+            "$id": "#/properties/researcher/properties/institution",
+            "type": "string",
+            "title": "The Institution Schema",
+            "default": "",
+            "examples": [
+              "UT"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      },
+      "experimental_conditions": {
+        "$id": "#/properties/experimental_conditions",
+        "type": "object",
+        "title": "The Experimental_conditions Schema"
+      },
+      "trials": {
+        "$id": "#/properties/trials",
+        "type": "array",
+        "title": "The Trials Schema",
+        "items": {
+          "$id": "#/properties/trials/items",
+          "type": "object",
+          "title": "The Items Schema"
+        }
+      }
+    }
+  }

--- a/src/schema/experiment_schema.json
+++ b/src/schema/experiment_schema.json
@@ -1,0 +1,126 @@
+{
+    "definitions": {},
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/root.json",
+    "type": "object",
+    "title": "The Root Schema",
+    "required": [
+      "name",
+      "technique",
+      "experiment_metadata",
+      "researcher",
+      "experimental_conditions",
+      "trials"
+    ],
+    "properties": {
+      "name": {
+        "$id": "#/properties/name",
+        "type": "string",
+        "title": "The Name Schema",
+        "default": "",
+        "examples": [
+          "Ion Exchange Membrane Sorption Tests"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "technique": {
+        "$id": "#/properties/technique",
+        "type": "object",
+        "title": "The Technique Schema",
+        "required": [
+          "name",
+          "technique_metadata"
+        ],
+        "properties": {
+          "name": {
+            "$id": "#/properties/technique/properties/name",
+            "type": "string",
+            "title": "The Name Schema",
+            "default": "",
+            "examples": [
+              "ion_exhcange_counter_and_mobile"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "technique_metadata": {
+            "$id": "#/properties/technique/properties/technique_metadata",
+            "type": "object",
+            "title": "The Technique_metadata Schema"
+          }
+        }
+      },
+      "experiment_metadata": {
+        "$id": "#/properties/experiment_metadata",
+        "type": "object",
+        "title": "The Experiment_metadata Schema"
+      },
+      "researcher": {
+        "$id": "#/properties/researcher",
+        "type": "object",
+        "title": "The Researcher Schema",
+        "required": [
+          "mwet_id",
+          "name",
+          "group",
+          "institution"
+        ],
+        "properties": {
+          "mwet_id": {
+            "$id": "#/properties/researcher/properties/mwet_id",
+            "type": "string",
+            "title": "The Mwet_id Schema",
+            "default": "",
+            "examples": [
+              "foo2"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "name": {
+            "$id": "#/properties/researcher/properties/name",
+            "type": "string",
+            "title": "The Name Schema",
+            "default": "",
+            "examples": [
+              "Rahul Sujanani"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "group": {
+            "$id": "#/properties/researcher/properties/group",
+            "type": "string",
+            "title": "The Group Schema",
+            "default": "",
+            "examples": [
+              "Freeman"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "institution": {
+            "$id": "#/properties/researcher/properties/institution",
+            "type": "string",
+            "title": "The Institution Schema",
+            "default": "",
+            "examples": [
+              "UT"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      },
+      "experimental_conditions": {
+        "$id": "#/properties/experimental_conditions",
+        "type": "object",
+        "title": "The Experimental_conditions Schema"
+      },
+      "trials": {
+        "$id": "#/properties/trials",
+        "type": "array",
+        "title": "The Trials Schema",
+        "items": {
+          "$id": "#/properties/trials/items",
+          "type": "object",
+          "title": "The Items Schema"
+        }
+      }
+    }
+  }

--- a/src/schema/user_schema.json
+++ b/src/schema/user_schema.json
@@ -1,0 +1,23 @@
+{
+    "definitions": {},
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "splash::schema::user",
+    "type": "object",
+    "title": "User Schema",
+    "properties": {
+      "uid": {
+        "description": "unique identifier",
+        "type": "string"
+      },
+      "groups": {
+        "description": "uids of groups that the user belongs to",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      }
+    },
+    "required": ["uid", "groups"]
+  }

--- a/src/views/AddCompound.vue
+++ b/src/views/AddCompound.vue
@@ -1,138 +1,20 @@
-<template lang="html">
-  <div id="app">
-    <v-app>
-      <v-content>
-        <v-container fluid grid-list-md>
-          <v-layout row>
-            <v-flex xs6>
-              <v-form ref="myForm" v-model="formValid">
-                <v-jsonschema-form
-                  v-if="schema"
-                  :schema="schema"
-                  :model="dataObject"
-                  :options="options"
-                  @error="e => window.alert(e)"
-                  @change="change"
-                  @input="input"
-                >
-                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
-                    Prepend slot<br>
-                  </template>
-                  <template v-slot:append-fullKeySlot="{fullSchema}">
-                    Append slot
-                  </template>
-                  <template v-slot:fullKeySlot="{fullSchema}">
-                    Full key slot: {{ fullSchema.description }}<br>
-                  </template>
-                  <template v-slot:custom-1="{fullSchema}">
-                    Custom display slot: {{ fullSchema.description }}
-                  </template>
-                </v-jsonschema-form>
-                <v-btn @click="handleClick">Add User</v-btn>
-                     <v-btn
-        color="error"
-        class="mr-4"
-        @click="reset"
-      >
-        Reset Form
-      </v-btn> 
-              </v-form>
-              <h2 class="title my-4" style="text-align: left;">
-                Data:
-              </h2>
-              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
-            </v-flex>
-          </v-layout>
-        </v-container>
-      </v-content>
-    </v-app>
+<template>
+  <div id='app'>
+    <form-factory :example="example" />
   </div>
 </template>
-
 <script>
-import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
-import examples from './examples'
-import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
-
-export default {
-  name: 'app',
-  components: { VJsonschemaForm },
-  data: function() {
-    return {
-      window,
-      schema: null,
-      schemaStr: '{}',
-      schemaError: null,
-      dataObject: {},
-      examples,
-      example: examples[2],
-      formValid: false,
-      options: null
-    }
-  },
-  mounted() {
-    if (window.location.search) {
-      //const key = window.location.search.replace('?example=', '')
-      //this.example = examples.find(e => e.key === key)
-    }
-    this.applyExample()
-  },
-  methods: {
-    applySchema() {
-      try {
-        this.schema = hjson.parse(this.schemaStr)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
+  import FormFactory from '@/components/FormFactory.vue' 
+  import SchemaInput from './examples/compound.js' 
+  export default {
+    data: function() {
+      return {
+        example: SchemaInput
       }
     },
-    formatSchema() {
-      try {
-        const schema = hjson.parse(this.schemaStr)
-        this.schemaStr = JSON.stringify(schema, null, 2)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
-      }
-    },
-    applyExample() {
-      const queryParams = `?example=${this.example.key}`
-      if (window.location.search !== queryParams) window.location.search = queryParams
-
-      this.schema = null
-      setTimeout(() => {
-        this.options = {
-          debug: true,
-          disableAll: false,
-          autoFoldObjects: true,
-          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
-          accordionMode: 'normal',
-          ...this.example.options || {}
-        }
-        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
-        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
-        this.applySchema()
-      }, 1)
-    },
-    change(e) {
-      console.log('"change" event', e)
-    },
-    input(e) {
-      console.log('"input" event', e)
-    },
-    handleClick() {
-      console.log('Add Sample clicked')
-      //axios.post('api/experiments', dataObject)
-    },
-    reset() {
-      this.$refs.myForm.reset()
-    },
+    components: {
+      FormFactory
+    }
   }
-}
+
 </script>
-
-<style lang="css">
-  pre {
-    text-align: left;
-  }
-</style>

--- a/src/views/AddCompound.vue
+++ b/src/views/AddCompound.vue
@@ -1,0 +1,138 @@
+<template lang="html">
+  <div id="app">
+    <v-app>
+      <v-content>
+        <v-container fluid grid-list-md>
+          <v-layout row>
+            <v-flex xs6>
+              <v-form ref="myForm" v-model="formValid">
+                <v-jsonschema-form
+                  v-if="schema"
+                  :schema="schema"
+                  :model="dataObject"
+                  :options="options"
+                  @error="e => window.alert(e)"
+                  @change="change"
+                  @input="input"
+                >
+                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
+                    Prepend slot<br>
+                  </template>
+                  <template v-slot:append-fullKeySlot="{fullSchema}">
+                    Append slot
+                  </template>
+                  <template v-slot:fullKeySlot="{fullSchema}">
+                    Full key slot: {{ fullSchema.description }}<br>
+                  </template>
+                  <template v-slot:custom-1="{fullSchema}">
+                    Custom display slot: {{ fullSchema.description }}
+                  </template>
+                </v-jsonschema-form>
+                <v-btn @click="handleClick">Add User</v-btn>
+                     <v-btn
+        color="error"
+        class="mr-4"
+        @click="reset"
+      >
+        Reset Form
+      </v-btn> 
+              </v-form>
+              <h2 class="title my-4" style="text-align: left;">
+                Data:
+              </h2>
+              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-content>
+    </v-app>
+  </div>
+</template>
+
+<script>
+import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
+import examples from './examples'
+import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+
+export default {
+  name: 'app',
+  components: { VJsonschemaForm },
+  data: function() {
+    return {
+      window,
+      schema: null,
+      schemaStr: '{}',
+      schemaError: null,
+      dataObject: {},
+      examples,
+      example: examples[2],
+      formValid: false,
+      options: null
+    }
+  },
+  mounted() {
+    if (window.location.search) {
+      //const key = window.location.search.replace('?example=', '')
+      //this.example = examples.find(e => e.key === key)
+    }
+    this.applyExample()
+  },
+  methods: {
+    applySchema() {
+      try {
+        this.schema = hjson.parse(this.schemaStr)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    formatSchema() {
+      try {
+        const schema = hjson.parse(this.schemaStr)
+        this.schemaStr = JSON.stringify(schema, null, 2)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    applyExample() {
+      const queryParams = `?example=${this.example.key}`
+      if (window.location.search !== queryParams) window.location.search = queryParams
+
+      this.schema = null
+      setTimeout(() => {
+        this.options = {
+          debug: true,
+          disableAll: false,
+          autoFoldObjects: true,
+          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
+          accordionMode: 'normal',
+          ...this.example.options || {}
+        }
+        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
+        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
+        this.applySchema()
+      }, 1)
+    },
+    change(e) {
+      console.log('"change" event', e)
+    },
+    input(e) {
+      console.log('"input" event', e)
+    },
+    handleClick() {
+      console.log('Add Sample clicked')
+      //axios.post('api/experiments', dataObject)
+    },
+    reset() {
+      this.$refs.myForm.reset()
+    },
+  }
+}
+</script>
+
+<style lang="css">
+  pre {
+    text-align: left;
+  }
+</style>

--- a/src/views/AddExperiment.vue
+++ b/src/views/AddExperiment.vue
@@ -1,138 +1,20 @@
-<template lang="html">
-  <div id="app">
-    <v-app>
-      <v-content>
-        <v-container fluid grid-list-md>
-          <v-layout row>
-            <v-flex xs6>
-              <v-form ref="myForm" v-model="formValid">
-                <v-jsonschema-form
-                  v-if="schema"
-                  :schema="schema"
-                  :model="dataObject"
-                  :options="options"
-                  @error="e => window.alert(e)"
-                  @change="change"
-                  @input="input"
-                >
-                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
-                    Prepend slot<br>
-                  </template>
-                  <template v-slot:append-fullKeySlot="{fullSchema}">
-                    Append slot
-                  </template>
-                  <template v-slot:fullKeySlot="{fullSchema}">
-                    Full key slot: {{ fullSchema.description }}<br>
-                  </template>
-                  <template v-slot:custom-1="{fullSchema}">
-                    Custom display slot: {{ fullSchema.description }}
-                  </template>
-                </v-jsonschema-form>
-                <v-btn @click="handleClick">Add Experiment</v-btn>
-                     <v-btn
-        color="error"
-        class="mr-4"
-        @click="reset"
-      >
-        Reset Form
-      </v-btn> 
-              </v-form>
-              <h2 class="title my-4" style="text-align: left;">
-                Data:
-              </h2>
-              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
-            </v-flex>
-          </v-layout>
-        </v-container>
-      </v-content>
-    </v-app>
+<template>
+  <div id='app'>
+    <form-factory :example="example" />
   </div>
 </template>
-
 <script>
-import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
-import examples from './examples'
-import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
-
-export default {
-  name: 'app',
-  components: { VJsonschemaForm },
-  data: function() {
-    return {
-      window,
-      schema: null,
-      schemaStr: '{}',
-      schemaError: null,
-      dataObject: {},
-      examples,
-      example: examples[1],
-      formValid: false,
-      options: null
-    }
-  },
-  mounted() {
-    if (window.location.search) {
-      //const key = window.location.search.replace('?example=', '')
-      //this.example = examples.find(e => e.key === key)
-    }
-    this.applyExample()
-  },
-  methods: {
-    applySchema() {
-      try {
-        this.schema = hjson.parse(this.schemaStr)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
+  import FormFactory from '@/components/FormFactory.vue' 
+  import SchemaInput from './examples/experiment.js' 
+  export default {
+    data: function() {
+      return {
+        example: SchemaInput
       }
     },
-    formatSchema() {
-      try {
-        const schema = hjson.parse(this.schemaStr)
-        this.schemaStr = JSON.stringify(schema, null, 2)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
-      }
-    },
-    applyExample() {
-      const queryParams = `?example=${this.example.key}`
-      if (window.location.search !== queryParams) window.location.search = queryParams
-
-      this.schema = null
-      setTimeout(() => {
-        this.options = {
-          debug: true,
-          disableAll: false,
-          autoFoldObjects: true,
-          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
-          accordionMode: 'normal',
-          ...this.example.options || {}
-        }
-        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
-        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
-        this.applySchema()
-      }, 1)
-    },
-    change(e) {
-      console.log('"change" event', e)
-    },
-    input(e) {
-      console.log('"input" event', e)
-    },
-    handleClick() {
-      console.log('Add Sample clicked')
-      //axios.post('api/experiments', dataObject)
-    },
-    reset() {
-      this.$refs.myForm.reset()
-    },
+    components: {
+      FormFactory
+    }
   }
-}
+
 </script>
-
-<style lang="css">
-  pre {
-    text-align: left;
-  }
-</style>

--- a/src/views/AddExperiment.vue
+++ b/src/views/AddExperiment.vue
@@ -1,0 +1,138 @@
+<template lang="html">
+  <div id="app">
+    <v-app>
+      <v-content>
+        <v-container fluid grid-list-md>
+          <v-layout row>
+            <v-flex xs6>
+              <v-form ref="myForm" v-model="formValid">
+                <v-jsonschema-form
+                  v-if="schema"
+                  :schema="schema"
+                  :model="dataObject"
+                  :options="options"
+                  @error="e => window.alert(e)"
+                  @change="change"
+                  @input="input"
+                >
+                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
+                    Prepend slot<br>
+                  </template>
+                  <template v-slot:append-fullKeySlot="{fullSchema}">
+                    Append slot
+                  </template>
+                  <template v-slot:fullKeySlot="{fullSchema}">
+                    Full key slot: {{ fullSchema.description }}<br>
+                  </template>
+                  <template v-slot:custom-1="{fullSchema}">
+                    Custom display slot: {{ fullSchema.description }}
+                  </template>
+                </v-jsonschema-form>
+                <v-btn @click="handleClick">Add Experiment</v-btn>
+                     <v-btn
+        color="error"
+        class="mr-4"
+        @click="reset"
+      >
+        Reset Form
+      </v-btn> 
+              </v-form>
+              <h2 class="title my-4" style="text-align: left;">
+                Data:
+              </h2>
+              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-content>
+    </v-app>
+  </div>
+</template>
+
+<script>
+import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
+import examples from './examples'
+import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+
+export default {
+  name: 'app',
+  components: { VJsonschemaForm },
+  data: function() {
+    return {
+      window,
+      schema: null,
+      schemaStr: '{}',
+      schemaError: null,
+      dataObject: {},
+      examples,
+      example: examples[1],
+      formValid: false,
+      options: null
+    }
+  },
+  mounted() {
+    if (window.location.search) {
+      //const key = window.location.search.replace('?example=', '')
+      //this.example = examples.find(e => e.key === key)
+    }
+    this.applyExample()
+  },
+  methods: {
+    applySchema() {
+      try {
+        this.schema = hjson.parse(this.schemaStr)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    formatSchema() {
+      try {
+        const schema = hjson.parse(this.schemaStr)
+        this.schemaStr = JSON.stringify(schema, null, 2)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    applyExample() {
+      const queryParams = `?example=${this.example.key}`
+      if (window.location.search !== queryParams) window.location.search = queryParams
+
+      this.schema = null
+      setTimeout(() => {
+        this.options = {
+          debug: true,
+          disableAll: false,
+          autoFoldObjects: true,
+          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
+          accordionMode: 'normal',
+          ...this.example.options || {}
+        }
+        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
+        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
+        this.applySchema()
+      }, 1)
+    },
+    change(e) {
+      console.log('"change" event', e)
+    },
+    input(e) {
+      console.log('"input" event', e)
+    },
+    handleClick() {
+      console.log('Add Sample clicked')
+      //axios.post('api/experiments', dataObject)
+    },
+    reset() {
+      this.$refs.myForm.reset()
+    },
+  }
+}
+</script>
+
+<style lang="css">
+  pre {
+    text-align: left;
+  }
+</style>

--- a/src/views/AddUser.vue
+++ b/src/views/AddUser.vue
@@ -1,0 +1,138 @@
+<template lang="html">
+  <div id="app">
+    <v-app>
+      <v-content>
+        <v-container fluid grid-list-md>
+          <v-layout row>
+            <v-flex xs6>
+              <v-form ref="myForm" v-model="formValid">
+                <v-jsonschema-form
+                  v-if="schema"
+                  :schema="schema"
+                  :model="dataObject"
+                  :options="options"
+                  @error="e => window.alert(e)"
+                  @change="change"
+                  @input="input"
+                >
+                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
+                    Prepend slot<br>
+                  </template>
+                  <template v-slot:append-fullKeySlot="{fullSchema}">
+                    Append slot
+                  </template>
+                  <template v-slot:fullKeySlot="{fullSchema}">
+                    Full key slot: {{ fullSchema.description }}<br>
+                  </template>
+                  <template v-slot:custom-1="{fullSchema}">
+                    Custom display slot: {{ fullSchema.description }}
+                  </template>
+                </v-jsonschema-form>
+                <v-btn @click="handleClick">Add User</v-btn>
+                     <v-btn
+        color="error"
+        class="mr-4"
+        @click="reset"
+      >
+        Reset Form
+      </v-btn> 
+              </v-form>
+              <h2 class="title my-4" style="text-align: left;">
+                Data:
+              </h2>
+              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-content>
+    </v-app>
+  </div>
+</template>
+
+<script>
+import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
+import examples from './examples'
+import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+
+export default {
+  name: 'app',
+  components: { VJsonschemaForm },
+  data: function() {
+    return {
+      window,
+      schema: null,
+      schemaStr: '{}',
+      schemaError: null,
+      dataObject: {},
+      examples,
+      example: examples[0],
+      formValid: false,
+      options: null
+    }
+  },
+  mounted() {
+    if (window.location.search) {
+      //const key = window.location.search.replace('?example=', '')
+      //this.example = examples.find(e => e.key === key)
+    }
+    this.applyExample()
+  },
+  methods: {
+    applySchema() {
+      try {
+        this.schema = hjson.parse(this.schemaStr)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    formatSchema() {
+      try {
+        const schema = hjson.parse(this.schemaStr)
+        this.schemaStr = JSON.stringify(schema, null, 2)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    applyExample() {
+      const queryParams = `?example=${this.example.key}`
+      if (window.location.search !== queryParams) window.location.search = queryParams
+
+      this.schema = null
+      setTimeout(() => {
+        this.options = {
+          debug: true,
+          disableAll: false,
+          autoFoldObjects: true,
+          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
+          accordionMode: 'normal',
+          ...this.example.options || {}
+        }
+        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
+        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
+        this.applySchema()
+      }, 1)
+    },
+    change(e) {
+      console.log('"change" event', e)
+    },
+    input(e) {
+      console.log('"input" event', e)
+    },
+    handleClick() {
+      console.log('Add Sample clicked')
+      //axios.post('api/experiments', dataObject)
+    },
+    reset() {
+      this.$refs.myForm.reset()
+    },
+  }
+}
+</script>
+
+<style lang="css">
+  pre {
+    text-align: left;
+  }
+</style>

--- a/src/views/AddUser.vue
+++ b/src/views/AddUser.vue
@@ -1,138 +1,20 @@
-<template lang="html">
-  <div id="app">
-    <v-app>
-      <v-content>
-        <v-container fluid grid-list-md>
-          <v-layout row>
-            <v-flex xs6>
-              <v-form ref="myForm" v-model="formValid">
-                <v-jsonschema-form
-                  v-if="schema"
-                  :schema="schema"
-                  :model="dataObject"
-                  :options="options"
-                  @error="e => window.alert(e)"
-                  @change="change"
-                  @input="input"
-                >
-                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
-                    Prepend slot<br>
-                  </template>
-                  <template v-slot:append-fullKeySlot="{fullSchema}">
-                    Append slot
-                  </template>
-                  <template v-slot:fullKeySlot="{fullSchema}">
-                    Full key slot: {{ fullSchema.description }}<br>
-                  </template>
-                  <template v-slot:custom-1="{fullSchema}">
-                    Custom display slot: {{ fullSchema.description }}
-                  </template>
-                </v-jsonschema-form>
-                <v-btn @click="handleClick">Add User</v-btn>
-                     <v-btn
-        color="error"
-        class="mr-4"
-        @click="reset"
-      >
-        Reset Form
-      </v-btn> 
-              </v-form>
-              <h2 class="title my-4" style="text-align: left;">
-                Data:
-              </h2>
-              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
-            </v-flex>
-          </v-layout>
-        </v-container>
-      </v-content>
-    </v-app>
+<template>
+  <div id='app'>
+    <form-factory :example="example" />
   </div>
 </template>
-
 <script>
-import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
-import examples from './examples'
-import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
-
-export default {
-  name: 'app',
-  components: { VJsonschemaForm },
-  data: function() {
-    return {
-      window,
-      schema: null,
-      schemaStr: '{}',
-      schemaError: null,
-      dataObject: {},
-      examples,
-      example: examples[0],
-      formValid: false,
-      options: null
-    }
-  },
-  mounted() {
-    if (window.location.search) {
-      //const key = window.location.search.replace('?example=', '')
-      //this.example = examples.find(e => e.key === key)
-    }
-    this.applyExample()
-  },
-  methods: {
-    applySchema() {
-      try {
-        this.schema = hjson.parse(this.schemaStr)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
+  import FormFactory from '@/components/FormFactory.vue' 
+  import SchemaInput from './examples/user.js' 
+  export default {
+    data: function() {
+      return {
+        example: SchemaInput
       }
     },
-    formatSchema() {
-      try {
-        const schema = hjson.parse(this.schemaStr)
-        this.schemaStr = JSON.stringify(schema, null, 2)
-        this.schemaError = null
-      } catch (err) {
-        this.schemaError = err
-      }
-    },
-    applyExample() {
-      const queryParams = `?example=${this.example.key}`
-      if (window.location.search !== queryParams) window.location.search = queryParams
-
-      this.schema = null
-      setTimeout(() => {
-        this.options = {
-          debug: true,
-          disableAll: false,
-          autoFoldObjects: true,
-          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
-          accordionMode: 'normal',
-          ...this.example.options || {}
-        }
-        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
-        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
-        this.applySchema()
-      }, 1)
-    },
-    change(e) {
-      console.log('"change" event', e)
-    },
-    input(e) {
-      console.log('"input" event', e)
-    },
-    handleClick() {
-      console.log('Add Sample clicked')
-      //axios.post('api/experiments', dataObject)
-    },
-    reset() {
-      this.$refs.myForm.reset()
-    },
+    components: {
+      FormFactory
+    }
   }
-}
+
 </script>
-
-<style lang="css">
-  pre {
-    text-align: left;
-  }
-</style>

--- a/src/views/DemoApp.vue
+++ b/src/views/DemoApp.vue
@@ -1,0 +1,160 @@
+<template lang="html">
+  <div id="app">
+    <v-app>
+      <v-content>
+        <v-container fluid grid-list-md>
+          <v-layout row>
+            <v-flex xs6>
+              <h2 class="title my-4">
+                Schema:
+              </h2>
+              <v-layout row wrap>
+                <v-flex xs6>
+                  <v-select v-model="example" :items="examples" :return-object="true" item-text="title" label="Choose an example" @change="applyExample" />
+                </v-flex>
+                <v-flex xs6>
+                  <v-container>
+                    <v-layout row wrap>
+                      <v-spacer />
+                      <v-btn text @click="formatSchema">
+                        Format
+                      </v-btn>
+                    </v-layout>
+                  </v-container>
+                </v-flex>
+              </v-layout>
+
+              <v-textarea v-model="schemaStr" :error-messages="schemaError ? [schemaError.message] : []" :rows="20" @input="applySchema" />
+
+              <h2 class="title my-4">
+                Options:
+              </h2>
+              <pre>{{ JSON.stringify(options, null, 2) }}</pre>
+            </v-flex>
+            <v-flex xs6>
+              <h2 class="title my-4">
+                Form
+                <v-chip v-if="formValid" color="success">
+                  valid
+                </v-chip>
+                <v-chip v-else color="danger">
+                  invalid
+                </v-chip>
+                <v-btn color="primary" @click="$refs.myForm.validate()">
+                  validate
+                </v-btn>
+              </h2>
+
+              <v-form ref="myForm" v-model="formValid">
+                <v-jsonschema-form
+                  v-if="schema"
+                  :schema="schema"
+                  :model="dataObject"
+                  :options="options"
+                  @error="e => window.alert(e)"
+                  @change="change"
+                  @input="input"
+                >
+                  <template v-slot:prepend-fullKeySlot="{fullSchema}">
+                    Prepend slot<br>
+                  </template>
+                  <template v-slot:append-fullKeySlot="{fullSchema}">
+                    Append slot
+                  </template>
+                  <template v-slot:fullKeySlot="{fullSchema}">
+                    Full key slot: {{ fullSchema.description }}<br>
+                  </template>
+                  <template v-slot:custom-1="{fullSchema}">
+                    Custom display slot: {{ fullSchema.description }}
+                  </template>
+                </v-jsonschema-form>
+              </v-form>
+              <h2 class="title my-4">
+                Data:
+              </h2>
+              <pre>{{ JSON.stringify(dataObject, null, 2) }}</pre>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-content>
+    </v-app>
+  </div>
+</template>
+
+<script>
+import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
+import examples from './examples'
+import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+
+export default {
+  name: 'app',
+  components: { VJsonschemaForm },
+  data: function() {
+    return {
+      window,
+      schema: null,
+      schemaStr: '{}',
+      schemaError: null,
+      dataObject: {},
+      examples,
+      example: examples[0],
+      formValid: false,
+      options: null
+    }
+  },
+  mounted() {
+    if (window.location.search) {
+      const key = window.location.search.replace('?example=', '')
+      this.example = examples.find(e => e.key === key)
+    }
+    this.applyExample()
+  },
+  methods: {
+    applySchema() {
+      try {
+        this.schema = hjson.parse(this.schemaStr)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    formatSchema() {
+      try {
+        const schema = hjson.parse(this.schemaStr)
+        this.schemaStr = JSON.stringify(schema, null, 2)
+        this.schemaError = null
+      } catch (err) {
+        this.schemaError = err
+      }
+    },
+    applyExample() {
+      const queryParams = `?example=${this.example.key}`
+      if (window.location.search !== queryParams) window.location.search = queryParams
+
+      this.schema = null
+      setTimeout(() => {
+        this.options = {
+          debug: true,
+          disableAll: false,
+          autoFoldObjects: true,
+          context: { owner: { type: 'organization', id: '5a5dc47163ebd4a6f438589b' } },
+          accordionMode: 'normal',
+          ...this.example.options || {}
+        }
+        this.dataObject = JSON.parse(JSON.stringify(this.example.data || {}))
+        this.schemaStr = JSON.stringify(this.example.schema, null, 2)
+        this.applySchema()
+      }, 1)
+    },
+    change(e) {
+      console.log('"change" event', e)
+    },
+    input(e) {
+      console.log('"input" event', e)
+    }
+  }
+}
+</script>
+
+<style lang="css">
+</style>

--- a/src/views/DemoApp.vue
+++ b/src/views/DemoApp.vue
@@ -85,6 +85,7 @@
 import VJsonschemaForm from '@koumoul/vuetify-jsonschema-form'
 import examples from './examples'
 import hjson from 'hjson' // more tolerant parsing of the schema for easier UX
+import axios from 'axios'
 
 export default {
   name: 'app',
@@ -99,7 +100,8 @@ export default {
       examples,
       example: examples[0],
       formValid: false,
-      options: null
+      options: null,
+      axios: axios,
     }
   },
   mounted() {
@@ -134,6 +136,7 @@ export default {
       this.schema = null
       setTimeout(() => {
         this.options = {
+          httpLib: this.axios,
           debug: true,
           disableAll: false,
           autoFoldObjects: true,

--- a/src/views/examples/accordion.js
+++ b/src/views/examples/accordion.js
@@ -1,0 +1,49 @@
+module.exports = {
+  title: 'Accordion',
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Combinations',
+    description: 'using a root allOf as an accordion',
+    type: 'object',
+    allOf: [{ $ref: '#/definitions/realWorldEntity' }, { $ref: '#/definitions/socialMediaEntity' }],
+    definitions: {
+      realWorldEntity: {
+        title: 'Main infos',
+        properties: {
+          address: {
+            type: 'string',
+            maxLength: 2000
+          },
+          credit_card: { type: 'number' }
+        },
+        dependencies: {
+          credit_card: {
+            properties: {
+              billing_address: { type: 'string' }
+            },
+            required: ['billing_address']
+          }
+        }
+      },
+      socialMediaEntity: {
+        title: 'Social media',
+        properties: {
+          twitter: {
+            type: 'string'
+          },
+          facebook: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  },
+  data: {
+    presentation: 'lorem ipsum',
+    twitter: 'koumoul_fr',
+    type: 'physicalPerson',
+    firstName: 'Alban',
+    lastName: 'Mouton'
+  }
+}

--- a/src/views/examples/arrays.js
+++ b/src/views/examples/arrays.js
@@ -1,0 +1,91 @@
+module.exports = {
+  title: 'Arrays',
+  schema: {
+    id: 'https://example.com/arrays.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    description: 'A representation of a person, company, organization, or place',
+    type: 'object',
+    properties: {
+      fruits: {
+        type: 'array',
+        description: 'This is a simple array of strings',
+        items: {
+          type: 'string'
+        }
+      },
+      sizes: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['small', 'medium', 'large']
+        },
+        minItems: 1
+      },
+      vegetables: {
+        type: 'array',
+        description: 'A list of vegetables as editable objects.',
+        items: { $ref: '#/definitions/veggie' }
+      },
+      fromAjaxObjects: {
+        type: 'array',
+        title: 'Tableau d\'objets depuis ajax présentés en liste',
+        description: 'The values come from an HTTP request and are stored as an array of objects.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title,schema&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href',
+        'x-display': 'list',
+        items: {
+          type: 'object',
+          properties: {
+            href: { type: 'string', 'x-display': 'hidden' },
+            title: { type: 'string', 'x-display': 'hidden' },
+            txtFromUser: { type: 'string', title: 'Additional field for user' }
+          }
+        }
+      },
+      coordinate: {
+        type: 'array',
+        title: 'Lat/lon coordinates as a tuple',
+        items: [{ type: 'number', title: 'Latitude' }, { type: 'number', title: 'Longitude' }]
+      }
+    },
+    definitions: {
+      veggie: {
+        type: 'object',
+        required: ['veggieName', 'veggieLike'],
+        properties: {
+          veggieName: {
+            type: 'string',
+            description: 'The name of the vegetable.'
+          },
+          veggieLike: {
+            type: 'boolean',
+            description: 'Do I like this vegetable?'
+          }
+        }
+      }
+    }
+  },
+  data: {
+    fruits: ['apple', 'orange', 'pear'],
+    vegetables: [
+      {
+        veggieName: 'potato',
+        veggieLike: true
+      },
+      {
+        veggieName: 'broccoli',
+        veggieLike: false
+      }
+    ],
+    fromAjaxObjects: [{
+      href: 'https://koumoul.com/s/data-fair/api/v1/datasets/jep-2018-france',
+      title: 'Journées européennes du patrimoine en France Métropolitaine',
+      txtFromUser: 'User already wrote stuff here'
+    }, {
+      href: 'OLD KEY',
+      title: 'This one does not match anymore an item from ajax query'
+    }]
+  }
+}

--- a/src/views/examples/basic.js
+++ b/src/views/examples/basic.js
@@ -1,0 +1,76 @@
+module.exports = {
+  title: 'Basic',
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Person',
+    description: 'A few metadata about some person. Rendered as a form by [vuetify-jsonschema-form](https://github.com/koumoul-dev/vuetify-jsonschema-form).',
+    type: 'object',
+    required: ['firstName', 'lastName'],
+    properties: {
+      type: {
+        type: 'string',
+        const: 'person'
+      },
+      firstName: {
+        type: 'string',
+        description: `
+The person's first name.
+
+This description can be a long text with markdown content.
+
+  - a list item
+  - another one
+  `,
+        'x-class': 'sm6 pr-4'
+      },
+      lastName: {
+        type: 'string',
+        description: "The person's last name.",
+        'x-class': 'sm6'
+      },
+      password: {
+        type: 'string',
+        'x-display': 'password'
+      },
+      age: {
+        description: 'Age in years which must be equal to or greater than zero.',
+        type: 'integer',
+        minimum: 0,
+        maximum: 150
+      },
+      ageSlider: {
+        description: 'Same age, but in a slider.',
+        type: 'integer',
+        'x-display': 'slider',
+        minimum: 0,
+        maximum: 150
+      },
+      internalKey: {
+        description: 'A property managed only internally by programs and hidden from user',
+        type: 'string',
+        'x-display': 'hidden'
+      },
+      citizen: {
+        description: 'Is this person a citizen of this country.',
+        type: 'boolean'
+      },
+      description: {
+        description: 'A longer text for the description.',
+        type: 'string',
+        maxLength: 2000
+      },
+      homepage: {
+        description: 'A long string also, but display is forced on single line',
+        type: 'string',
+        maxLength: 2000,
+        'x-display': 'single-line'
+      }
+    }
+  },
+  data: {
+    firstName: 'John',
+    lastName: 'Doe',
+    age: 21
+  }
+}

--- a/src/views/examples/combinations.js
+++ b/src/views/examples/combinations.js
@@ -1,0 +1,126 @@
+module.exports = {
+  title: 'Combinations',
+  schema: {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Combinations',
+    description: 'Using anyOf and allOf combinations. ',
+    type: 'object',
+    properties: {
+      entity: {
+        type: 'object',
+        properties: {
+          presentation: {
+            title: 'Presentation (neither in a anyOf or a oneOf)',
+            description: 'A longer text for the description.',
+            type: 'string',
+            maxLength: 2000
+          }
+        },
+        required: ['type'],
+        allOf: [{ $ref: '#/definitions/realWorldEntity' }, { $ref: '#/definitions/socialMediaEntity' }],
+        oneOf: [{ $ref: '#/definitions/physicalPerson' }, { $ref: '#/definitions/moralPerson' }]
+      }
+    },
+    definitions: {
+      realWorldEntity: {
+        title: 'Real world (first part of allOf)',
+        properties: {
+          address: {
+            type: 'string',
+            maxLength: 2000
+          },
+          credit_card: { type: 'number' }
+        },
+        dependencies: {
+          credit_card: {
+            properties: {
+              billing_address: { type: 'string' }
+            },
+            required: ['billing_address']
+          }
+        }
+      },
+      socialMediaEntity: {
+        title: 'Social media (second part of allOf)',
+        properties: {
+          twitter: {
+            type: 'string'
+          },
+          facebook: {
+            type: 'string'
+          }
+        }
+      },
+      legal: {
+        properties: {
+          twitter: {
+            type: 'string'
+          },
+          facebook: {
+            type: 'string'
+          }
+        }
+      },
+      physicalPerson: {
+        title: 'Physical person',
+        properties: {
+          type: {
+            type: 'string',
+            title: 'Type of person (select based on a oneOf)',
+            const: 'physicalPerson'
+          }
+        },
+        allOf: [{
+          type: 'object',
+          title: 'Name (first part of a allOf inside the oneOf)',
+          properties: {
+            firstName: {
+              type: 'string',
+              description: "The person's first name."
+            },
+            lastName: {
+              type: 'string',
+              description: "The person's last name."
+            }
+          }
+        }, {
+          type: 'object',
+          title: 'Other info (second part of allOf inside the oneOf)',
+          properties: {
+            age: {
+              description: 'Age in years which must be equal to or greater than zero.',
+              type: 'integer',
+              minimum: 0
+            },
+            gender: {
+              type: 'string',
+              enum: ['male', 'female', 'other']
+            }
+          }
+        }]
+      },
+      moralPerson: {
+        title: 'Moral person',
+        properties: {
+          type: {
+            type: 'string',
+            const: 'moralPerson'
+          },
+          organizationType: {
+            type: 'string',
+            enum: ['non-profit', 'for-profit']
+          }
+        }
+      }
+    }
+  },
+  data: {
+    entity: {
+      presentation: 'lorem ipsum',
+      twitter: 'koumoul_fr',
+      type: 'moralPerson',
+      firstName: 'Alban',
+      lastName: 'Mouton'
+    }
+  }
+}

--- a/src/views/examples/compound.js
+++ b/src/views/examples/compound.js
@@ -1,0 +1,6 @@
+module.exports={
+  title: 'Compound',
+  schema: require('@/schema/compounds_schema.json'),
+  data: {
+  }
+}

--- a/src/views/examples/dependencies.js
+++ b/src/views/examples/dependencies.js
@@ -1,0 +1,49 @@
+module.exports = {
+  title: 'Dependencies',
+  schema: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      acceptTC: {
+        title: 'Accept terms and conditions',
+        type: 'boolean'
+      }
+    },
+    dependencies: {
+      acceptTC: {
+        oneOf: [{ $ref: '#/definitions/creditCardPayment' }, { $ref: '#/definitions/paypalPayment' }]
+      }
+    },
+    definitions: {
+      creditCardPayment: {
+        title: 'Credit card payment',
+        properties: {
+          type: { const: 'creditcardpayment' },
+          credit_card: { type: 'number' }
+        },
+        required: ['name'],
+        dependencies: {
+          credit_card: {
+            properties: {
+              billing_address: { type: 'string' }
+            },
+            required: ['billing_address']
+          }
+        }
+      },
+      paypalPayment: {
+        title: 'Paypal payment',
+        properties: {
+          type: { const: 'paypalpayment' },
+          'paypal account': { type: 'string' }
+        },
+        required: ['account']
+      }
+    }
+  },
+  data: {
+    // acceptTC: true,
+    // type: 'creditcardpayment',
+    // credit_card: 10
+  }
+}

--- a/src/views/examples/experiment.js
+++ b/src/views/examples/experiment.js
@@ -1,0 +1,6 @@
+module.exports={
+  title: 'Experiment',
+  schema: require('@/schema/experiment_schema.json'),
+  data: {
+  }
+}

--- a/src/views/examples/icons.js
+++ b/src/views/examples/icons.js
@@ -1,0 +1,72 @@
+module.exports = {
+  title: 'Icons',
+  schema: {
+    type: 'object',
+    properties: {
+      fromEnum: {
+        title: 'From enum',
+        type: 'string',
+        description: 'The values are icon codes coming from an enum.',
+        'x-display': 'icon',
+        enum: ['mdi-alarm', 'mdi-alarm-plus', 'mdi-alarm-off']
+      },
+      fromEnumArray: {
+        title: 'From enum in array',
+        type: 'array',
+        description: 'The values are icon codes coming from an enum and are put into an array',
+        'x-display': 'icon',
+        items: {
+          type: 'string',
+          enum: ['mdi-alarm', 'mdi-alarm-plus', 'mdi-alarm-off']
+        }
+      },
+      fromOneOf: {
+        title: 'From oneOf',
+        type: 'string',
+        description: "The values are icon codes coming from a oneOf choice with 'const' and 'title' attributes.",
+        'x-display': 'icon',
+        oneOf: [{ const: 'mdi-alarm', title: 'Alarm', icon: 'mdi-alarm' }, { const: 'mdi-alarm-plus', title: 'Alarm plus', icon: 'mdi-alarm-plus' }]
+      },
+      fromAjaxImages: {
+        title: 'From Ajax Images',
+        type: 'object',
+        description: 'The values are URLs to SVG icons fetched from an API.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets/icons-mdi-latest/lines?q={q}',
+        'x-itemKey': 'name',
+        'x-itemTitle': 'name',
+        'x-itemIcon': '_attachment_url',
+        'x-itemsProp': 'results',
+        properties: {
+          name: {
+            type: 'string'
+          },
+          _attachment_url: {
+            type: 'string'
+          }
+        }
+      },
+      fromAjaxSVG: {
+        title: 'From Ajax SVG',
+        type: 'object',
+        description: 'The values are raw SVG icons fetched from an API.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets/icons-mdi-latest/lines?q={q}',
+        'x-itemKey': 'name',
+        'x-itemTitle': 'name',
+        'x-itemIcon': 'svg',
+        'x-itemsProp': 'results',
+        properties: {
+          name: {
+            type: 'string'
+          },
+          svg: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  },
+  data: {
+    fromEnumArray: ['mdi-alarm', 'mdi-alarm-plus'],
+    fromOneOf: 'mdi-alarm'
+  }
+}

--- a/src/views/examples/index.js
+++ b/src/views/examples/index.js
@@ -1,0 +1,20 @@
+const keys = [
+  'user',
+  'experiment',
+  'compound',
+  'basic',
+  'arrays',
+  'pickers',
+  'validation',
+  'selects',
+  'nested',
+  'dependencies',
+  'combinations',
+  'accordion',
+  'tabs',
+  'vertical-tabs',
+  'icons',
+  'slots',
+]
+
+module.exports = keys.map(key => ({ ...require('./' + key), key }))

--- a/src/views/examples/lists.js
+++ b/src/views/examples/lists.js
@@ -1,0 +1,65 @@
+module.exports = {
+  title: 'Lists',
+  schema: {
+    title: 'Person',
+    type: 'object',
+    required: ['gender', 'fromAjaxObject', 'fromAjaxString'],
+    properties: {
+      fromEnumArray: {
+        title: 'From enum in array displayed as a list',
+        type: 'array',
+        description: 'The values are simple strings coming from an enum and are put into an array',
+        items: {
+          type: 'string',
+          enum: ['value1', 'value2', 'value3']
+        },
+        'x-display': 'list'
+      },
+      fromOneOfArray: {
+        title: 'From oneOf in array displayed as a list',
+        type: 'array',
+        description: "The values are simple strings coming from a oneOf choice with 'const' and 'title' attributes and put into an array.",
+        items: {
+          type: 'string',
+          oneOf: [{ const: 'v1', title: 'title1' }, { const: 'v2', title: 'title2' }]
+        },
+        'x-display': 'list'
+      },
+      fromAjaxStringArray: {
+        title: 'From ajax in array displayed as a list',
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        description: 'The values come from an HTTP request and are put into an array.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href',
+        'x-display': 'list'
+      },
+      fromAjaxObjectArray: {
+        type: 'array',
+        title: 'From ajax object in array displayed as a list',
+        description: 'The values come from an HTTP request and are stored as objects in an array.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title,schema&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href',
+        'x-display': 'list',
+        items: {
+          type: 'object',
+          properties: {
+            href: { type: 'string', 'x-display': 'hidden' },
+            title: { type: 'string', 'x-display': 'hidden' },
+            otherField: {
+              title: 'This field is added to the item by user',
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  },
+  data: {}
+}

--- a/src/views/examples/nested.js
+++ b/src/views/examples/nested.js
@@ -1,0 +1,69 @@
+module.exports = {
+  title: 'Nested',
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Person',
+    description: 'A few metadata about some person in a nested object structure.',
+    type: 'object',
+    required: ['name'],
+    properties: {
+      type: {
+        type: 'string',
+        const: 'person'
+      },
+      name: {
+        type: 'object',
+        required: ['firstName', 'lastName'],
+        properties: {
+          firstName: {
+            type: 'string',
+            description: "The person's first name."
+          },
+          lastName: {
+            type: 'string',
+            description: "The person's last name."
+          }
+        }
+      },
+      others: {
+        type: 'object',
+        title: 'Other optional data',
+        properties: {
+          alive: {
+            type: 'boolean',
+            default: true
+          },
+          age: {
+            description: 'Age in years which must be equal to or greater than zero.',
+            type: 'integer',
+            minimum: 0
+          },
+          description: {
+            description: 'A longer text for the description.',
+            type: 'string',
+            maxLength: 2000
+          },
+          homepage: {
+            description: 'A long string also, but display is forced on single line',
+            type: 'string',
+            maxLength: 2000,
+            'x-display': 'single-line'
+          }
+        }
+      },
+      parents: {
+        type: 'array',
+        title: 'Optional data about parents',
+        items: [{
+          type: 'string',
+          title: 'Parent 1'
+        }, {
+          type: 'string',
+          title: 'Parent 2'
+        }]
+      }
+    }
+  },
+  data: {}
+}

--- a/src/views/examples/pickers.js
+++ b/src/views/examples/pickers.js
@@ -1,0 +1,46 @@
+module.exports = {
+  title: 'Pickers: date, time and color.',
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Person',
+    type: 'object',
+    properties: {
+      aDate: {
+        title: 'A date',
+        type: 'string',
+        format: 'date',
+        description: 'A date.'
+      },
+      aDateTime: {
+        title: 'A date in date-time format',
+        type: 'string',
+        format: 'date-time'
+      },
+      aTime: {
+        title: 'A time',
+        type: 'string',
+        format: 'time',
+        description: 'A time.'
+      },
+      colorSwatches: {
+        title: 'A color using the minimalist swatches picker',
+        description: 'In hex format',
+        type: 'string',
+        format: 'hexcolor'
+      },
+      colorPicker: {
+        title: 'A color using a more complete picker',
+        description: 'In hex format',
+        type: 'string',
+        format: 'hexcolor',
+        'x-display': 'color-picker'
+      }
+    }
+  },
+  data: {
+    // aHexColor: '#03A9F4'
+    // aDate: '1983-11-28T',
+    // aDateTime: '2018-09-17T21:17:40.033Z'
+  }
+}

--- a/src/views/examples/selects.js
+++ b/src/views/examples/selects.js
@@ -1,0 +1,198 @@
+module.exports = {
+  title: 'Selects',
+  schema: {
+    title: 'Person',
+    type: 'object',
+    required: ['gender', 'fromAjaxObject', 'fromAjaxString'],
+    properties: {
+      fromEnum: {
+        title: 'From enum',
+        type: 'string',
+        description: 'The values are simple strings coming from an enum.',
+        enum: ['value1', 'value2', 'value3']
+      },
+      fromEnumOfObjects: {
+        title: 'From enum of objects',
+        type: 'object',
+        description: 'The values are objects coming from an enum.',
+        enum: [{ value: 'v1', title: 'title1' }, { value: 'v2', title: 'title2' }],
+        'x-itemTitle': 'title',
+        'x-itemKey': 'value'
+      },
+      fromEnumArray: {
+        title: 'From enum in array',
+        type: 'array',
+        description: 'The values are simple strings coming from an enum and are put into an array',
+        items: {
+          type: 'string',
+          enum: ['value1', 'value2', 'value3']
+        }
+      },
+      fromOneOf: {
+        title: 'From oneOf',
+        type: 'string',
+        description: "The values are simple strings coming from a oneOf choice with 'const' and 'title' attributes.",
+        oneOf: [{ const: 'v1', title: 'title1' }, { const: 'v2', title: 'title2' }]
+      },
+      fromOneOfArray: {
+        title: 'From oneOf in array',
+        type: 'array',
+        description: "The values are simple strings coming from a oneOf choice with 'const' and 'title' attributes and put into an array.",
+        items: {
+          type: 'string',
+          oneOf: [{ const: 'v1', title: 'title1' }, { const: 'v2', title: 'title2' }]
+        }
+      },
+      fromAjaxString: {
+        type: 'string',
+        description: 'The values come from an HTTP request.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href'
+      },
+      fromAjaxStringArray: {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        description: 'The values come from an HTTP request and are put into an array.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href'
+      },
+      fromAjaxObject: {
+        type: 'object',
+        description: 'The values come from an HTTP request and are stored as object.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title,schema&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href',
+        properties: {
+          href: { type: 'string' },
+          title: { type: 'string' },
+          page: { type: 'string' },
+          schema: { type: 'array' }
+        }
+      },
+      fromAjaxArrayOfObjects: {
+        type: 'array',
+        description: 'The values come from an HTTP request and are stored as objects in an array.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title,schema&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href',
+        items: {
+          type: 'object',
+          properties: {
+            href: { type: 'string' },
+            title: { type: 'string' }
+          }
+        }
+      },
+      fromData: {
+        type: 'object',
+        description: 'The values come from another part of the data.',
+        'x-fromData': 'fromAjaxObject.schema',
+        'x-itemTitle': 'x-originalName',
+        'x-itemKey': 'key'
+      },
+      fromAjaxWithQuery: {
+        type: 'object',
+        description: 'The values come from an HTTP request with textual filter.',
+        'x-fromUrl': 'https://koumoul.com/s/data-fair/api/v1/datasets?status=finalized&select=title&q={q}&owner={context.owner.type}:{context.owner.id}',
+        'x-itemsProp': 'results',
+        'x-itemTitle': 'title',
+        'x-itemKey': 'href'
+      },
+      chartDef: {
+        // Simple oneOf on object, the title of const property is used as title of the select
+        type: 'object',
+        'x-itemKey': 'type',
+        oneOf: [{
+          title: 'Bar chart',
+          properties: {
+            type: {
+              const: 'bar',
+              title: 'Chose from a type (from oneOf of objects)'
+            },
+            xLabel: {
+              type: 'string'
+            },
+            yLabel: {
+              type: 'string'
+            },
+            fromAjaxWithDep: {
+              type: 'object',
+              title: 'choisir un colonne',
+              description: 'The values come from an HTTP request with a part of the url that depends on another part of the model.',
+              'x-fromUrl': '{fromAjaxWithQuery.href}/schema',
+              'x-itemTitle': 'label',
+              'x-itemKey': 'key'
+            }
+          }
+        }, {
+          title: 'Pie chart',
+          properties: {
+            type: {
+              const: 'pie'
+            },
+            diameter: {
+              type: 'integer'
+            }
+          }
+        }]
+      },
+      chartDef2: {
+        title: 'Chose from a type (fron oneOf of objects with a description)',
+        description: 'A conditional form will be rendered below',
+        type: 'object',
+        'x-itemKey': 'type',
+        oneOf: [{
+          title: 'Bar chart',
+          properties: {
+            type: {
+              const: 'bar'
+            },
+            xLabel: {
+              type: 'string'
+            },
+            yLabel: {
+              type: 'string'
+            }
+          }
+        }, {
+          title: 'Pie chart',
+          properties: {
+            type: {
+              const: 'pie'
+            },
+            diameter: {
+              type: 'integer'
+            }
+          }
+        }]
+      }
+    }
+  },
+  data: {
+    /* fromEnum: 'other',
+    fromEnumArray: ['other'],
+    fromOneOf: 'other',
+    fromOneOfArray: ['other'],
+    fromAjaxString: 'other',
+    fromAjaxStringArray: ['other'],
+    fromAjaxObject: {href: 'other', title: 'Other'},
+    fromData: {key: 'other', 'x-originalName': 'Other'},
+    fromAjaxWithQuery: {href: 'other', title: 'Other'},
+    */
+    chartDef: {
+      type: 'pie',
+      diameter: '10'
+    },
+    chartDef2: {
+      type: 'pie'
+    }
+  }
+}

--- a/src/views/examples/slots.js
+++ b/src/views/examples/slots.js
@@ -1,0 +1,20 @@
+module.exports = {
+  title: 'Slots',
+  schema: {
+    type: 'object',
+    properties: {
+      fullKeySlot: {
+        title: 'Full key slot',
+        type: 'string',
+        description: 'This property is rendered using a slot named with its key "firstName".'
+      },
+      customDisplay1: {
+        title: 'Custom display 1',
+        type: 'string',
+        description: 'This property is rendered using a slot named with a x-display="custom-XXX" property.',
+        'x-display': 'custom-1'
+      }
+    }
+  },
+  data: {}
+}

--- a/src/views/examples/tabs.js
+++ b/src/views/examples/tabs.js
@@ -1,0 +1,52 @@
+module.exports = {
+  title: 'Tabs',
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Combinations',
+    description: 'Rendering a root allOf as tabs',
+    type: 'object',
+    'x-options': {
+      allOfTabs: true
+    },
+    allOf: [{ $ref: '#/definitions/realWorldEntity' }, { $ref: '#/definitions/socialMediaEntity' }],
+    definitions: {
+      realWorldEntity: {
+        title: 'Main infos',
+        properties: {
+          address: {
+            type: 'string',
+            maxLength: 2000
+          },
+          credit_card: { type: 'number' }
+        },
+        dependencies: {
+          credit_card: {
+            properties: {
+              billing_address: { type: 'string' }
+            },
+            required: ['billing_address']
+          }
+        }
+      },
+      socialMediaEntity: {
+        title: 'Social media',
+        properties: {
+          twitter: {
+            type: 'string'
+          },
+          facebook: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  },
+  data: {
+    presentation: 'lorem ipsum',
+    twitter: 'koumoul_fr',
+    type: 'physicalPerson',
+    firstName: 'Alban',
+    lastName: 'Mouton'
+  }
+}

--- a/src/views/examples/user.js
+++ b/src/views/examples/user.js
@@ -1,0 +1,6 @@
+module.exports={
+  title: 'User',
+  schema: require('@/schema/user_schema.json'),
+  data: {
+  }
+}

--- a/src/views/examples/validation.js
+++ b/src/views/examples/validation.js
@@ -1,0 +1,28 @@
+module.exports = {
+  title: 'Validation',
+  schema: {
+    title: 'Person',
+    type: 'object',
+    required: ['firstName'],
+    properties: {
+      firstName: {
+        type: 'string',
+        description: "The person's first name."
+      },
+      lastName: {
+        type: 'string',
+        description: "The person's last name."
+      },
+      age: {
+        description: 'Age in years which must be equal to or greater than zero.',
+        type: 'integer',
+        minimum: 0
+      }
+    }
+  },
+  data: {
+    firstName: 'John',
+    lastName: 'Doe',
+    age: 21
+  }
+}

--- a/src/views/examples/vertical-tabs.js
+++ b/src/views/examples/vertical-tabs.js
@@ -1,0 +1,53 @@
+module.exports = {
+  title: 'Vertical tabs',
+  options: {
+    allOfTabs: true,
+    tabsMode: 'vertical'
+  },
+  schema: {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Combinations',
+    description: 'Rendering a root allOf as tabs',
+    type: 'object',
+    allOf: [{ $ref: '#/definitions/realWorldEntity' }, { $ref: '#/definitions/socialMediaEntity' }],
+    definitions: {
+      realWorldEntity: {
+        title: 'Main infos',
+        properties: {
+          address: {
+            type: 'string',
+            maxLength: 2000
+          },
+          credit_card: { type: 'number' }
+        },
+        dependencies: {
+          credit_card: {
+            properties: {
+              billing_address: { type: 'string' }
+            },
+            required: ['billing_address']
+          }
+        }
+      },
+      socialMediaEntity: {
+        title: 'Social media',
+        properties: {
+          twitter: {
+            type: 'string'
+          },
+          facebook: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  },
+  data: {
+    presentation: 'lorem ipsum',
+    twitter: 'koumoul_fr',
+    type: 'physicalPerson',
+    firstName: 'Alban',
+    lastName: 'Mouton'
+  }
+}


### PR DESCRIPTION
Isssue
------
For Issue #20 

Two goals have been **satisfied**:
> * [x]  Look into auto-generation of form UI based on json schema. For each splash category, we have a schema file that describes the structure of the data in mongo and validates data on input.
> * [x]  Create a form to input user data

Feature
--------
* It is mainly developed by two package `Vuetify` and `vuetify-jsonschema-form`.
* The schema file under `schema` directory is copied and pasted from `spalsh-server`. No change.
* There is a `Schema2Form Dev` in Home page. It the demo of `vuetify-jsonschema-form` and could be a useful tool for further development. It has realtime translate from jsonschema on the left to form on the right
* `data` is print out for development mode under form. We may keep or remove them in production.
* `Add *` button only log information right now, not submit anything to backend yet.