### PR TITLE
Build npm in docker and get client id from server at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-###
-# This file creates an image that is for development only.
-###
+# https://vuejs.org/v2/cookbook/dockerize-vuejs-app.html
 
-FROM node
-
-# make the 'app' folder the current working directory
+# build stage
+FROM node:lts-alpine as build-stage
 WORKDIR /app
-
-# copy both 'package.json' and 'package-lock.json' (if available)
 COPY package*.json ./
-
-# install project dependencies
 RUN npm install
-
-# copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY . .
+RUN npm run build
+
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ let settings = null;
 
 Vue.use({
   async install(Vue) {
+    getSettings()
     Vue.prototype.$settings = settings;
     let searchUrl = '/elasticsearch';
     Vue.prototype.$api = axios.create({
@@ -59,12 +60,7 @@ async function onGoogleLoad() {
 
     
   // Initializes it with the correct client ID
-    await window.gapi.auth2.init(
-      {
-      // client_id: process.env.VUE_APP_CLIENT_ID.concat(
-      //   '.apps.googleusercontent.com',
-      // ),
-      
+    await window.gapi.auth2.init({     
       client_id: settings.google_client_id
     });
   } catch (e) {
@@ -90,7 +86,7 @@ async function getSettings(){
   }
 }
 
-document.onload = getSettings();
+// document.onload = getSettings();
 
 // Construct src element for google sign in script
 const script = document.createElement('script');

--- a/src/main.js
+++ b/src/main.js
@@ -10,26 +10,18 @@ import FiveHundred from './views/500.vue';
 import router from './router';
 import store from './store';
 import './assets/css/main.css';
+import { axisBottom } from 'd3';
 
 Vue.use(BootstrapVue);
 Vue.use(Router);
-// Vue.component('plotly', Plotly);
-
 Vue.config.productionTip = false;
+let apiUrl = apiUrl = '/api/v1';
+let settings = null;
 
 Vue.use({
-  install(Vue) {
-    let apiUrl = process.env.VUE_APP_API_URL;
-    if (apiUrl == null) {
-      apiUrl = '/api/v1';
-    }
-    let searchUrl = process.env.VUE_APP_API_URL;
-    if (searchUrl == null) {
-      searchUrl = '/elasticsearch';
-    }
-    // Vue.prototype.$http = axios.create({
-
-    // });
+  async install(Vue) {
+    Vue.prototype.$settings = settings;
+    let searchUrl = '/elasticsearch';
     Vue.prototype.$api = axios.create({
       baseURL: apiUrl,
     });
@@ -64,11 +56,16 @@ async function onGoogleLoad() {
   // of the app: https://developers.google.com/identity/sign-in/web/reference
   await new Promise((resolve) => window.gapi.load('auth2', resolve));
   try {
+
+    
   // Initializes it with the correct client ID
-    await window.gapi.auth2.init({
-      client_id: process.env.VUE_APP_CLIENT_ID.concat(
-        '.apps.googleusercontent.com',
-      ),
+    await window.gapi.auth2.init(
+      {
+      // client_id: process.env.VUE_APP_CLIENT_ID.concat(
+      //   '.apps.googleusercontent.com',
+      // ),
+      
+      client_id: settings.google_client_id
     });
   } catch (e) {
     console.log(e);
@@ -86,6 +83,14 @@ async function onGoogleLoad() {
   }).$mount('#app');
 }
 
+async function getSettings(){
+  let response = await axios.get(apiUrl + "/settings")
+  if (response.data){
+    settings = response.data;
+  }
+}
+
+document.onload = getSettings();
 
 // Construct src element for google sign in script
 const script = document.createElement('script');


### PR DESCRIPTION
Two things that are related...so I'm putting them both in one PR:

1. Creates a docker build that runs `npm run build`  while building.

2. Because the `npm run build` is now running at docker image creation time, the calls that we used to make in vue `process.env` are no longer valid. So, this now call /settings endpoint in the splash-server to do things like get the client id. 